### PR TITLE
Update nordpool_scheduling_automation_example.yaml

### DIFF
--- a/config_examples/nordpool_scheduling_automation_example.yaml
+++ b/config_examples/nordpool_scheduling_automation_example.yaml
@@ -91,8 +91,6 @@ input_boolean:
   waterheater_scheduled:
     name: Cheapest hours scheduled for the waterheater for the next day.
     icon: mdi:clock
-
-input_boolean:
   carcharger_scheduled:
     name: Cheapest hours scheduled for the carcharger for the next day.
     icon: mdi:clock


### PR DESCRIPTION
duplicate input_boolean: Removed one to make both carcharger and watherheater work out of the box.